### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/docker/ansible/Dockerfile
+++ b/docker/ansible/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update ;\
         python3-dev \
         python3-minimal \
         python3-pip ;\
-    pip3 install --upgrade wheel setuptools ;\
-    pip3 install --upgrade ansible openstacksdk python-openstackclient python-heatclient openshift ;\
+    pip3 install --no-cache-dir --upgrade wheel setuptools ;\
+    pip3 install --no-cache-dir --upgrade ansible openstacksdk python-openstackclient python-heatclient openshift ;\
     curl -o /usr/local/bin/kubectl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" ;\
     chmod +x /usr/local/bin/kubectl ;\
     apt-get purge -y \


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>